### PR TITLE
Changed ID of span where full slug is picked up from

### DIFF
--- a/modules/permalinks/assets/js/meta-box.js
+++ b/modules/permalinks/assets/js/meta-box.js
@@ -77,7 +77,7 @@
                     slug = $('#editable-post-name input').val();
 
                     if (typeof slug === 'undefined' || slug === '') {
-                        slug = $('#edit-slug-box #editable-post-name').text();
+                        slug = $('#edit-slug-box #editable-post-name-full').text();
                     }
 
                     if (typeof slug === 'undefined' || slug === '') {


### PR DESCRIPTION
## Description
URL requirement is broken by ellipsis, colon and other characters (issue#301).

## Benefits
Fixes bug in allowing the "Latin characters in permalink" rule to work for long URLs and ones with invalid character.

## Possible drawbacks
None found in testing.

## Applicable issues
https://github.com/publishpress/PublishPress-Checklists/issues/301

## Checklist
- [ x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x ] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [ x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x ] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x ] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
