### PR TITLE
olatechpro:feature/#173-add-a-permission-to-access-to_Checklists-screen

### DIFF
--- a/modules/checklists/checklists.php
+++ b/modules/checklists/checklists.php
@@ -52,6 +52,8 @@ if (!class_exists('PPCH_Checklists')) {
 
         const FLAG_OPTIONS_MIGRATED_2_0_0 = 'publishpress_checklists_options_migrated_2_0_0';
 
+        const FLAG_OPTIONS_MIGRATED_2_6_0 = 'publishpress_checklists_options_migrated_2_6_0';
+
         /**
          * @var string
          */
@@ -117,10 +119,16 @@ if (!class_exists('PPCH_Checklists')) {
             );
 
             $this->module = $legacyPlugin->register_module($this->module_name, $args);
+
+            //add checklist capability
+            add_filter('publishpress_checklists_manage_checklist_cap', [$this, 'checklists_manage_capability']);
+
         }
 
         public function migrateLegacyOptions()
         {
+            global $wp_roles;
+
             if (wp_doing_ajax()) {
                 return;
             }
@@ -142,6 +150,22 @@ if (!class_exists('PPCH_Checklists')) {
                 }
 
                 update_option(self::FLAG_OPTIONS_MIGRATED_2_0_0, true);
+            }
+
+            // Do 2.6.0 migration
+            if (!(bool)get_option(self::FLAG_OPTIONS_MIGRATED_2_6_0) && function_exists( 'get_role' )) {
+                //add newly introduced checklist role for roles with manage_options 
+                $all_roles = $wp_roles->roles;
+                if(is_array($all_roles) && !empty($all_roles)) {
+                    foreach ($all_roles as $role => $details) {
+                        $role = get_role($role);
+                        if ($role->has_cap('manage_options')) {
+                            $role->add_cap( 'manage_checklists' );
+                        }
+                    }
+                }
+
+                update_option(self::FLAG_OPTIONS_MIGRATED_2_6_0, true);
             }
         }
 
@@ -1043,5 +1067,16 @@ if (!class_exists('PPCH_Checklists')) {
 
             return $new_requirements_array;
         }
+
+
+        /**
+         * Add checklist capability
+         *
+         */
+        public function checklists_manage_capability($capability)
+        {
+            return 'manage_checklists';
+        }
+        
     }
 }

--- a/modules/checklists/checklists.php
+++ b/modules/checklists/checklists.php
@@ -153,14 +153,14 @@ if (!class_exists('PPCH_Checklists')) {
             }
 
             // Do 2.6.0 migration
-            if (!(bool)get_option(self::FLAG_OPTIONS_MIGRATED_2_6_0) && function_exists( 'get_role' )) {
+            if (!(bool)get_option(self::FLAG_OPTIONS_MIGRATED_2_6_0) && function_exists('get_role')) {
                 //add newly introduced checklist role for roles with manage_options 
                 $all_roles = $wp_roles->roles;
                 if(is_array($all_roles) && !empty($all_roles)) {
                     foreach ($all_roles as $role => $details) {
                         $role = get_role($role);
                         if ($role->has_cap('manage_options')) {
-                            $role->add_cap( 'manage_checklists' );
+                            $role->add_cap('manage_checklists');
                         }
                     }
                 }

--- a/readme.txt
+++ b/readme.txt
@@ -281,6 +281,10 @@ With the PublishPress Checklists plugin, you can require that site's content mee
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+= [2.6.0] - [===UNRELEASED===] =
+
+* Added: Permission to access Checklists screen #173
+
 = [2.5.3] - 2021-11-15 =
 
 * Fixed: Can't update published posts if requirements changed


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Checklists plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Checklists/blob/master/CONTRIBUTING.md
 -->

## Description
- Added a permission to access Checklists screen in relation to #173

## Benefits
Checklist screen will no longer use 'manage_options' but 'manage_checklists'

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
https://github.com/publishpress/PublishPress-Checklists/issues/173

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
