### PR TITLE
feature/#642_WordPress_6.5_causes_Checklists_button_to_shift

### DIFF
--- a/modules/checklists/assets/css/post-editor-checklists.css
+++ b/modules/checklists/assets/css/post-editor-checklists.css
@@ -18,6 +18,12 @@
     font-weight: bold;
 }
 
+.interface-pinned-items button.components-button[aria-label='Checklists'] {
+    padding: 0 !important;
+    background: transparent !important;
+    width: auto !important;
+}
+
 /* Warning icon in the Publish button */
 body.ppch-show-publishing-warning-icon #publishing-action, /* Classic Editor */
 body.ppch-show-publishing-warning-icon .pp-checklists-toolbar-icon {


### PR DESCRIPTION
WordPress 6.5 causes Checklists button to shift fix #642