### PR TITLE
Fixed Select2 strings are not displayed translated

### DIFF
--- a/modules/checklists/assets/js/global-checklists.js
+++ b/modules/checklists/assets/js/global-checklists.js
@@ -389,7 +389,16 @@
       $icon = $('<span>').addClass('dashicons dashicons-no').attr('data-id', id).attr('data-type', type).appendTo($a);
 
       // Re-initialize select 2
-      $('#pp-checklists-global select').select2();
+      $('#pp-checklists-global select').select2({
+        language: {
+          noResults: function () {
+            return objectL10n_checklists_global_checklist.noResults;
+          },
+          searching: function () {
+            return objectL10n_checklists_global_checklist.searching;
+          }
+        },
+      });
 
       $a.on('click', function(event) {
         callback_remove_row(event);

--- a/modules/checklists/checklists.php
+++ b/modules/checklists/checklists.php
@@ -645,6 +645,8 @@ if (!class_exists('PPCH_Checklists')) {
                             'Which roles can mark this task as complete?',
                             'publishpress-checklists'
                         ),
+                        'noResults'         => esc_html__('No results found', 'publishpress-checklists'),
+                        'searching'         => esc_html__('Searching…', 'publishpress-checklists'),
                         'remove'            => esc_html__('Remove', 'publishpress-checklists'),
                         'custom_enter_name' => esc_html__('Enter name of custom task', 'publishpress-checklists'),
                         'openai_enter_name' => esc_html__('Enter OpenAI task prompt', 'publishpress-checklists'),

--- a/modules/checklists/checklists.php
+++ b/modules/checklists/checklists.php
@@ -852,7 +852,7 @@ if (!class_exists('PPCH_Checklists')) {
                         ),
                         'show_warning_icon_submit' => Base_requirement::VALUE_YES === $legacyPlugin->settings->module->options->show_warning_icon_submit,
                         'disable_publish_button'   => Base_requirement::VALUE_YES === $legacyPlugin->settings->module->options->disable_publish_button,
-                        'title_warning_icon'       => esc_html__('One or more items in the checklist are not completed'),
+                        'title_warning_icon'       => esc_html__('One or more items in the checklist are not completed', 'publishpress-checklists'),
                         'is_gutenberg_active'      => $this->is_gutenberg_active(),
                         'user_can_manage_options'  => current_user_can('manage_options'),
                         'configure_url'            => esc_url($this->get_admin_link()),

--- a/modules/permissions/assets/js/admin.js
+++ b/modules/permissions/assets/js/admin.js
@@ -1,5 +1,14 @@
 jQuery(function ($) {
-    $('#pp-checklists-global select').select2();
+    $('#pp-checklists-global select').select2({
+        language: {
+          noResults: function () {
+            return objectL10n_checklists_global_checklist.noResults;
+          },
+          searching: function () {
+            return objectL10n_checklists_global_checklist.searching;
+          }
+        },
+      });
     // Re-initialize select 2 with ajax
     function initializeSelect2(selector, identifier) {
         $(selector).select2({
@@ -24,6 +33,14 @@ jQuery(function ($) {
                         pagination: { more: res.data.has_next },
                     };
                 },
+            },
+            language: {
+                noResults: function () {
+                    return objectL10n_checklists_global_checklist.noResults;
+                },
+                searching: function () {
+                    return objectL10n_checklists_global_checklist.searching;
+                }
             },
         });
     }


### PR DESCRIPTION
Hello.

Select2 strings:

noResults: "No results found"

searching: "Searching…"

are now displayed translated.

Fix #1010 