### PR TITLE
Fix rename label preview for default checklist editor labels

### DIFF
--- a/modules/checklists/assets/js/global-checklists.js
+++ b/modules/checklists/assets/js/global-checklists.js
@@ -816,6 +816,14 @@
         return formatTimeForPreview($timeInput.val());
       }
 
+      function getDefaultEditorLabelFromWrapper($wrapper) {
+        if (!$wrapper || !$wrapper.length) {
+          return '';
+        }
+
+        return $.trim($wrapper.find('.pp-checklists-edit-label').attr('data-editor-default-label') || '');
+      }
+
       function updateEditorPreview($wrapper, editorLabel) {
         if (!editorPanelRenameEnabled) {
           return;
@@ -829,8 +837,30 @@
         }
 
         var trimmedEditorLabel = $.trim(editorLabel || '');
+        var isUsingDefaultEditorLabel = trimmedEditorLabel === '';
+        if (trimmedEditorLabel === '') {
+          trimmedEditorLabel = getDefaultEditorLabelFromWrapper($wrapper);
+        }
+
         if (trimmedEditorLabel === '') {
           $previewValue.text(previewDefault);
+          return;
+        }
+
+        if (isUsingDefaultEditorLabel) {
+          var defaultMultipleValue = getMultipleSuffixFromRow($wrapper);
+          if (trimmedEditorLabel.indexOf('%s') !== -1) {
+            $previewValue.text(trimmedEditorLabel.replace(/%s/g, defaultMultipleValue));
+            return;
+          }
+
+          var defaultTimeValue = getTimeSuffixFromRow($wrapper);
+          if (trimmedEditorLabel.indexOf('%time%') !== -1) {
+            $previewValue.text(trimmedEditorLabel.replace(/%time%/g, defaultTimeValue));
+            return;
+          }
+
+          $previewValue.text(trimmedEditorLabel);
           return;
         }
 

--- a/modules/checklists/checklists.php
+++ b/modules/checklists/checklists.php
@@ -684,7 +684,7 @@ if (!class_exists('PPCH_Checklists')) {
                             'publishpress-checklists'
                         ),
                         'rename_modal_admin_label' => esc_html__(
-                            'Label for WP Admin / backend',
+                            'Label for the Checklists screen',
                             'publishpress-checklists'
                         ),
                         'rename_modal_admin_placeholder' => esc_html__(
@@ -692,7 +692,7 @@ if (!class_exists('PPCH_Checklists')) {
                             'publishpress-checklists'
                         ),
                         'rename_modal_editor_label' => esc_html__(
-                            'Label for Editing screen / frontend',
+                            'Label for the post editing screen',
                             'publishpress-checklists'
                         ),
                         'rename_modal_editor_placeholder' => esc_html__(


### PR DESCRIPTION
## Summary
- fall back to the stored default editor label when the rename field is left empty
- render default placeholder-based labels correctly for multiple and time requirements
- keep custom editor label previews using the existing suffix behavior
- update rename modal copy to use clearer Checklists and post editing screen labels