### PR TITLE
Fix validation for anchor and relative links

### DIFF
--- a/core/Utils/HyperlinkValidator.php
+++ b/core/Utils/HyperlinkValidator.php
@@ -19,8 +19,128 @@ class HyperlinkValidator
      */
     public function isValidLink($link)
     {
-        $linkWithoutFragment = explode('#', $link)[0];
+        $link = trim((string)$link);
 
-        return (bool)preg_match('/^(?:(#[-a-zA-Z0-9@:%._\+~#=]{0,256})|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9-]{2,63}\b(?:[-a-zA-Z0-9()@;:%_\+.~#?&\/\/=*]*)|tel:\+?[0-9\-]+|mailto:[a-z0-9\-_\.]+@[a-z0-9\-_\.]+?[a-z0-9@\.\?=\s\%,\-&_;*]+)$/i', $linkWithoutFragment);
+        if ($link === '') {
+            return false;
+        }
+
+        if ($this->isValidAnchorLink($link)) {
+            return true;
+        }
+
+        $linkWithoutFragment = $this->removeFragment($link);
+
+        if ($this->isValidHttpLink($linkWithoutFragment)) {
+            return true;
+        }
+
+        if ($this->isValidRelativeLink($linkWithoutFragment)) {
+            return true;
+        }
+
+        if ($this->isValidTelephoneLink($linkWithoutFragment)) {
+            return true;
+        }
+
+        if ($this->isValidMailtoLink($linkWithoutFragment)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return string
+     */
+    private function removeFragment($link)
+    {
+        if ($link === '' || $link[0] === '#') {
+            return $link;
+        }
+
+        $fragmentPosition = strpos($link, '#');
+
+        if ($fragmentPosition === false) {
+            return $link;
+        }
+
+        return substr($link, 0, $fragmentPosition);
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return bool
+     */
+    private function isValidAnchorLink($link)
+    {
+        return (bool)preg_match('/^#[-a-zA-Z0-9@:%._\+~#=]{1,256}$/', $link);
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return bool
+     */
+    private function isValidHttpLink($link)
+    {
+        if (strpos($link, '//') === 0) {
+            $link = 'https:' . $link;
+        }
+
+        if (!preg_match('/^https?:\/\//i', $link)) {
+            return false;
+        }
+
+        return filter_var($link, FILTER_VALIDATE_URL) !== false;
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return bool
+     */
+    private function isValidRelativeLink($link)
+    {
+        return (bool)preg_match('/^(?:\/|\.\.?\/|\?)[^\s]*$/', $link);
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return bool
+     */
+    private function isValidTelephoneLink($link)
+    {
+        return (bool)preg_match('/^tel:\+?[0-9\-]+$/i', $link);
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return bool
+     */
+    private function isValidMailtoLink($link)
+    {
+        if (stripos($link, 'mailto:') !== 0) {
+            return false;
+        }
+
+        $addressAndQuery = substr($link, 7);
+        $parts = explode('?', $addressAndQuery, 2);
+        $address = $parts[0];
+
+        if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
+            return false;
+        }
+
+        if (!isset($parts[1]) || $parts[1] === '') {
+            return true;
+        }
+
+        return (bool)preg_match('/^[^?\s]+$/', $parts[1]);
     }
 }

--- a/core/Utils/HyperlinkValidator.php
+++ b/core/Utils/HyperlinkValidator.php
@@ -19,7 +19,11 @@ class HyperlinkValidator
      */
     public function isValidLink($link)
     {
-        $link = trim((string)$link);
+        if (!is_string($link)) {
+            return false;
+        }
+
+        $link = trim($link);
 
         if ($link === '') {
             return false;
@@ -29,25 +33,22 @@ class HyperlinkValidator
             return true;
         }
 
+        // tel: and mailto: are opaque: a "#" is part of the value, not a fragment.
+        if ($this->isValidTelephoneLink($link)) {
+            return true;
+        }
+
+        if ($this->isValidMailtoLink($link)) {
+            return true;
+        }
+
         $linkWithoutFragment = $this->removeFragment($link);
 
         if ($this->isValidHttpLink($linkWithoutFragment)) {
             return true;
         }
 
-        if ($this->isValidRelativeLink($linkWithoutFragment)) {
-            return true;
-        }
-
-        if ($this->isValidTelephoneLink($linkWithoutFragment)) {
-            return true;
-        }
-
-        if ($this->isValidMailtoLink($linkWithoutFragment)) {
-            return true;
-        }
-
-        return false;
+        return $this->isValidRelativeLink($linkWithoutFragment);
     }
 
     /**
@@ -77,7 +78,7 @@ class HyperlinkValidator
      */
     private function isValidAnchorLink($link)
     {
-        return (bool)preg_match('/^#[-a-zA-Z0-9@:%._\+~#=]{1,256}$/', $link);
+        return (bool)preg_match('/^#[-a-zA-Z0-9@:%._\+~=]{1,256}$/', $link);
     }
 
     /**
@@ -95,7 +96,18 @@ class HyperlinkValidator
             return false;
         }
 
-        return filter_var($link, FILTER_VALIDATE_URL) !== false;
+        if (filter_var($link, FILTER_VALIDATE_URL) === false) {
+            return false;
+        }
+
+        // FILTER_VALIDATE_URL accepts dotless hosts such as "http://invalidlinkcom".
+        $host = parse_url($link, PHP_URL_HOST);
+
+        if (empty($host)) {
+            return false;
+        }
+
+        return (bool)preg_match('/\.[a-z0-9-]{2,63}$/i', $host);
     }
 
     /**
@@ -105,7 +117,16 @@ class HyperlinkValidator
      */
     private function isValidRelativeLink($link)
     {
-        return (bool)preg_match('/^(?:\/|\.\.?\/|\?)[^\s]*$/', $link);
+        if (preg_match('/^\?[^\s]+$/', $link)) {
+            return true;
+        }
+
+        if (!preg_match('/^(?:\.\.?)?\/[^\s]*$/', $link)) {
+            return false;
+        }
+
+        // Reject paths made only of separators, such as "/", "//" or "../".
+        return trim($link, './') !== '';
     }
 
     /**
@@ -129,18 +150,11 @@ class HyperlinkValidator
             return false;
         }
 
-        $addressAndQuery = substr($link, 7);
+        $addressAndQuery = substr($link, strlen('mailto:'));
         $parts = explode('?', $addressAndQuery, 2);
-        $address = $parts[0];
 
-        if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
-            return false;
-        }
-
-        if (!isset($parts[1]) || $parts[1] === '') {
-            return true;
-        }
-
-        return (bool)preg_match('/^[^?\s]+$/', $parts[1]);
+        // Only the address is validated. Query values such as "subject" or "body"
+        // are free text and may legitimately contain spaces and commas.
+        return filter_var($parts[0], FILTER_VALIDATE_EMAIL) !== false;
     }
 }

--- a/tests/integration/PublishPress/Checklists/Core/Utils/HyperlinkValidatorCest.php
+++ b/tests/integration/PublishPress/Checklists/Core/Utils/HyperlinkValidatorCest.php
@@ -34,6 +34,10 @@ class HyperlinkValidatorCest
      * @example ["/relative path/with spaces"]
      * @example ["../relative path/with spaces"]
      * @example ["?invalid query"]
+     * @example ["/"]
+     * @example ["//"]
+     * @example ["../"]
+     * @example ["?"]
      */
     public function isValidLinkWithInvalidLinkReturnsFalse(WpunitTester $I, Example $example)
     {
@@ -71,6 +75,7 @@ class HyperlinkValidatorCest
      * @example ["?preview=true"]
      * @example ["//cdn.example.com/image.jpg"]
      * @example ["https://validlink.com/#section"]
+     * @example ["mailto:test@example.com?subject=Issue #12 from Our Site"]
      */
     public function isValidLinkWithValidLinkReturnsTrue(WpunitTester $I, Example $example)
     {

--- a/tests/integration/PublishPress/Checklists/Core/Utils/HyperlinkValidatorCest.php
+++ b/tests/integration/PublishPress/Checklists/Core/Utils/HyperlinkValidatorCest.php
@@ -30,6 +30,10 @@ class HyperlinkValidatorCest
      * @example ["mailto:testexample.com?subject=Mail from Our Site"]
      * @example ["mailt:someone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&bcc=lastperson@theirsite.com&subject=Big%20News"]
      * @example ["mailtosomeone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&bcc=lastperson@theirsite.com&subject=Big%20News&body=Body-goes-here"]
+     * @example ["#"]
+     * @example ["/relative path/with spaces"]
+     * @example ["../relative path/with spaces"]
+     * @example ["?invalid query"]
      */
     public function isValidLinkWithInvalidLinkReturnsFalse(WpunitTester $I, Example $example)
     {
@@ -59,6 +63,14 @@ class HyperlinkValidatorCest
      * @example ["mailto:someone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&bcc=lastperson@theirsite.com&subject=Big%20News"]
      * @example ["mailto:someone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&bcc=lastperson@theirsite.com&subject=Big%20News&body=Body-goes-here"]
      * @example ["mailto:someone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&bcc=lastperson@theirsite.com&amp;subject=Big%20News&body=Body-goes-here"]
+     * @example ["#checklist-item"]
+     * @example ["/sample-page"]
+     * @example ["/sample-page?preview=true"]
+     * @example ["../sample-page"]
+     * @example ["./sample-page"]
+     * @example ["?preview=true"]
+     * @example ["//cdn.example.com/image.jpg"]
+     * @example ["https://validlink.com/#section"]
      */
     public function isValidLinkWithValidLinkReturnsTrue(WpunitTester $I, Example $example)
     {

--- a/tests/integration/core/Requirement/Validate_linksCest.php
+++ b/tests/integration/core/Requirement/Validate_linksCest.php
@@ -93,6 +93,10 @@ class Validate_linksCest
      * @example ["mailto:someone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&bcc=lastperson@theirsite.com&subject=Big%20News"]
      * @example ["mailto:someone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&bcc=lastperson@theirsite.com&subject=Big%20News&body=Body-goes-here"]
      * @example ["mailto:someone@yoursite.com?cc=someoneelse@theirsite.com, another@thatsite.com, me@mysite.com&amp;bcc=lastperson@theirsite.com&amp;subject=Big%20News&amp;body=Body-goes-here"]
+     * @example ["#checklist-item"]
+     * @example ["/sample-page"]
+     * @example ["../sample-page"]
+     * @example ["?preview=true"]
      */
     public function getCurrentStatusForContentWithValidLinkReturnsTrue(WpunitTester $I, Example $example)
     {


### PR DESCRIPTION
## Summary
This fixes the link validator so valid in-page anchor links and relative links are not incorrectly marked as invalid.

## Changes
- preserve and validate anchor-only links such as 
- accept relative URLs such as , , , and 
- keep support for HTTP(S), , and  links
- add integration coverage for the validator and  requirement

## Testing
- added integration test cases for anchor links
- added integration test cases for relative links
- unable to run the PHP test suite in this environment because  is not installed on the PATH